### PR TITLE
Start docs resources

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+    - Demonstrating empathy and kindness toward other people
+    - Being respectful of differing opinions, viewpoints, and experiences
+    - Giving and gracefully accepting constructive feedback
+    - Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+    - Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+    - The use of sexualized language or imagery, and sexual attention or advances of any kind
+    - Trolling, insulting or derogatory comments, and personal or political attacks
+    - Public or private harassment
+    - Publishing others' private information, such as a physical or email address, without their explicit permission
+    - Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at Contact method. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+### **1. Correction**
+
+**Community Impact:** Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+### **2. Warning**
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### **3. Temporary Ban**
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### **4. Permanent Ban**
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+Attribution
+
+-----
+This Code of Conduct is adapted from the Contributor Covenant, version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by Mozilla's code of conduct enforcement ladder.
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# CGAP Contributing Guide
+
+Thank you for investing your time in contributing to our project!
+
+Read our [Code of Conduct](https://github.com/dbmi-bgm/cgap-issues/blob/main/CODE_OF_CONDUCT.md) to keep our community approachable and respectable.
+
+In this guide you will get an overview of the contribution workflow from opening an issue, creating a PR, reviewing, and merging the PR.
+
+
+## New contributor guide
+
+To get an overview of the project, read the [README](https://github.com/dbmi-bgm/cgap-issues/blob/main/README.md); for high-level, cross-repository documentation, take a look at the [Wiki](https://github.com/dbmi-bgm/cgap-issues/wiki).
+
+## Getting started
+
+To navigate our codebase with confidence, see the CGAP Infrastructure Overview page on the wiki (coming soon).
+
+Check [here](https://cgap.hms.harvard.edu/getinvolved) to see what types of contributions we accept before making changes. Many of them don't require writing a single line of code.
+
+
+# Issues
+
+## Create a new issue
+
+If you spot a technical problem or bug in CGAP, please first search to see if an issue for that topic already exists. If a related issue doesn't exist, you can open a new issue using the most relevant issue template.
+
+## Solve an issue
+
+Scan through our existing issues to find one that interests you. You can narrow down the search using labels as filters. If you find an issue to work on, you are welcome to open a PR with a fix. See the Making Changes and Updates section below for more information.
+
+## Editing the Wiki
+Note that editing the Wiki directly is currently limited to Collaborators only. If you have a suggestion for a Wiki page or edit, create an issue using the Wiki template.
+
+## Making Changes and Updates
+1. Create an issue for the bug/issue first in `cgap-issues`, if one has not already been created. This can be a good way to request information on where and how to make the edits.
+
+2. Once you have located the repository where you'd like to make your changes, set up the portal or repository according to the repo's instructions.
+
+    *Note that sometimes multiple repositories may have to be updated in order to complete an edit (for instance, updating `Shared-Portal-Components` and `CGAP-Portal` to complete a Portal UI task).*
+
+3. Create a new branch from the most recent master branch in the following format: 
+
+    ```(github-username)-(branch-title)```
+
+4. Commit your changes in that branch. Don't forget to add or update unit tests and comments!
+
+5. Push your branch to remote/origin, and create a pull request with the appropriate template and label for your updates. Don't forget to link to the pull request from the issue you created in `cgap-issues`, to ensure someone on the team sees it.
+
+6. Once it's ready for review, set it as ready for review.
+
+7. Wait for review to be complete. We may ask for additional changes before your PR can be merged, using suggested changes or pull request comments. Commit any other edits to your branch.
+
+8. Once your branch has been approved, we'll handle the merging of the branch to master and any merge conflicts that arise.
+
+9. Congrats! Your PR is merged. The CGAP team thanks you! 🎉🎉
+
+Once your PR is merged, your contributions will be deployed at the next release.


### PR DESCRIPTION
Started putting together some more detailed docs for the code of conduct and contributor pages.

Most of what was in https://github.com/dbmi-bgm/cgap-portal/blob/master/CONTRIBUTING.rst has already been worked into the Wiki and Readme for this repo. These more detailed documents will be linked to from the currently existing Wiki page.

I also think it could make sense to have both of these files be the standard templates across the organization.